### PR TITLE
Add stripes-acq-components to bring in translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@folio/plugin-find-po-line": ">=1.0.0",
     "@folio/plugin-find-user": ">=1.5.0",
     "@folio/stripes": "^2.0.0",
+    "@folio/stripes-acq-components": "^1.0.0",
     "@folio/stripes-erm-components": "^2.0.0",
     "@folio/tenant-settings": "^2.9.0",
     "@folio/tags": ">=1.3.0",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -25,6 +25,7 @@ module.exports = {
     '@folio/plugin-find-organization': {},
     '@folio/plugin-find-po-line': {},
     '@folio/plugin-find-user': {},
+    '@folio/stripes-acq-components': {},
     '@folio/stripes-erm-components': {},
     '@folio/tags': {},
     '@folio/tenant-settings': {},


### PR DESCRIPTION
We need to include stripes-acq-components so that Stripes brings in the translations when serving the bundle.