### PR TITLE
Removed resolutions from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@folio/agreements": ">=2.0.0",
     "@folio/erm-usage": ">=1.0.3",
+    "@folio/eholdings": ">=1.0.0",
     "@folio/local-kb-admin": ">=1.0.0",
     "@folio/licenses": ">=2.0.0",
     "@folio/notes": ">=1.0.0",
@@ -44,13 +45,5 @@
   },
   "devDependencies": {
     "@folio/stripes-cli": ">=1.10.0"
-  },
-  "resolutions": {
-    "lodash": "^4.17.13",
-    "lodash.mergewith": "^4.6.2",
-    "lodash-es": "^4.17.14",
-    "lodash.defaultsdeep": "^4.6.1",
-    "final-form": "4.18.5",
-    "react-final-form": "6.3.0"
   }
 }

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -13,6 +13,7 @@ module.exports = {
   modules: {
     '@folio/agreements': {},
     '@folio/erm-usage': {},
+    '@folio/eholdings': {},
     '@folio/local-kb-admin': {},
     '@folio/licenses': {},
     '@folio/notes': {},


### PR DESCRIPTION
https://github.com/folio-org/stripes-final-form/pull/19 allows us to not need the old (broken?) behaviour of final-form so I wanted to remove that `resolutions` entry.

And the `lodash` resolutions aren't being maintained in platform-complete anymore ([snapshot](https://github.com/folio-org/platform-complete/blob/snapshot/package.json), [release](https://github.com/folio-org/platform-complete/blob/master/package.json)) so I removed those to bring us back into sync with platform-complete.