### PR TITLE
Remove stripes-acq-components from platform-erm

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@folio/plugin-find-po-line": ">=1.0.0",
     "@folio/plugin-find-user": ">=1.5.0",
     "@folio/stripes": "^6.0.0",
-    "@folio/stripes-acq-components": ">=2.0.0",
     "@folio/stripes-erm-components": ">=5.0.0",
     "@folio/tags": ">=1.3.0",
     "@folio/tenant-settings": ">=2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/platform-erm",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "repository": "folio-org/platform-erm",
   "publishConfig": {

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  okapi: { 'url':'http://localhost:9130', 'tenant':'diku' },
+  okapi: { 'url': 'http://localhost:9130', 'tenant': 'diku' },
   config: {
     // autoLogin: { username: 'diku_admin', password: 'admin' }
     // disableAuth: false
@@ -31,7 +31,6 @@ module.exports = {
     '@folio/plugin-find-package-title': {},
     '@folio/plugin-find-po-line': {},
     '@folio/plugin-find-user': {},
-    '@folio/stripes-acq-components': {},
     '@folio/stripes-erm-components': {},
     '@folio/tags': {},
     '@folio/tenant-settings': {},


### PR DESCRIPTION
stripes-acq-components was brought in only to have its translations work with orders in platform-erm. But, now that its included as a part of stripesDeps in orders, we can remove it from platform-erm.