### PR TITLE
ERM-2998: Upgrade platform-erm React to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/platform-erm",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "repository": "folio-org/platform-erm",
   "publishConfig": {
@@ -14,7 +14,9 @@
     "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; stripes serve $f",
     "test": "echo 'No unit tests implemented'",
     "test-int": "stripes test nightmare stripes.config.js",
-    "lint": "eslint test/ui-testing"
+    "lint": "eslint test/ui-testing",
+    "clean": "rm -rf ../node_modules ../*/node_modules ../yarn.lock",
+    "clean-install": "yarn clean && yarn install --ignore-scripts"
   },
   "dependencies": {
     "@folio/agreements": ">=2.0.0",
@@ -38,19 +40,19 @@
     "@folio/plugin-find-package-title": ">=1.0.0",
     "@folio/plugin-find-po-line": ">=1.0.0",
     "@folio/plugin-find-user": ">=1.5.0",
-    "@folio/stripes": "^8.0.0",
+    "@folio/stripes": "^9.0.0",
     "@folio/stripes-erm-components": ">=6.0.0",
     "@folio/tags": ">=1.3.0",
     "@folio/tenant-settings": ">=2.9.0",
     "moment": "~2.29.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-intl": "^5.8.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },
   "devDependencies": {
-    "@folio/stripes-cli": "^2.0.0",
+    "@folio/stripes-cli": "^3.0.0",
     "react-intl": "^5.8.1"
   },
   "resolutions": {


### PR DESCRIPTION
Bumped platform versions to react 18 and stripes 9 Bumped major version of platform

Added yarn clean and yarn clean-install scripts

ERM-2998, STRIPES-870